### PR TITLE
fix: add terminateOperation flag to /sync call

### DIFF
--- a/.changeset/bright-queens-raise.md
+++ b/.changeset/bright-queens-raise.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-argo-cd': patch
+---
+
+Adding the terminateOperation flag to the /sync endpoint. It is an optional boolean flag that can be set to true and it will terminate the previous Sync in progress before starting a new sync. This is a non-breaking change because if the flag is not provided and set to true the existing logic will not be impacted.

--- a/plugins/backend/backstage-plugin-argo-cd-backend/src/service/router.ts
+++ b/plugins/backend/backstage-plugin-argo-cd-backend/src/service/router.ts
@@ -353,8 +353,13 @@ export function createRouter({
   });
   router.post('/sync', async (request, response) => {
     const appSelector = request.body.appSelector;
+    const terminateOperation: boolean =
+      Boolean(request.body.terminateOperation) ?? false;
     try {
-      const argoSyncResp = await argoSvc.resyncAppOnAllArgos({ appSelector });
+      const argoSyncResp = await argoSvc.resyncAppOnAllArgos({
+        appSelector,
+        terminateOperation,
+      });
       return response.send(argoSyncResp);
     } catch (e: any) {
       return response.status(e.status || 500).send({

--- a/plugins/backend/backstage-plugin-argo-cd-backend/src/service/types.ts
+++ b/plugins/backend/backstage-plugin-argo-cd-backend/src/service/types.ts
@@ -127,6 +127,7 @@ export interface SyncArgoApplicationProps {
 
 export interface ResyncProps {
   appSelector: string;
+  terminateOperation?: boolean;
 }
 
 export interface ArgoServiceApi {


### PR DESCRIPTION
<!-- Please describe what these changes achieve -->
https://github.com/AAInternal/runway/issues/6263
#### :heavy_check_mark: Checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [x] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)

before: 
<img width="663" alt="image" src="https://github.com/user-attachments/assets/b1a93438-38d7-468c-8fb5-9dac066752d6">

after: 
<img width="668" alt="image" src="https://github.com/user-attachments/assets/7a54ee84-5856-48c0-948f-36beede5e6d4">
